### PR TITLE
Fix Terminal.app color rendering issues

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -68,10 +68,10 @@ func NewModel(repo acronym.Repository) Model {
 	ti.CharLimit = 100
 	ti.Width = 50
 	
-	// Set cursor to orange using the Cursor properties
-	ti.TextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF"))
-	ti.Cursor.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF6600")).Background(lipgloss.Color("#FF6600"))
-	ti.Cursor.TextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF6600"))
+	// Set cursor to orange using adaptive colors for compatibility
+	ti.TextStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "15"})
+	ti.Cursor.Style = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "202", Dark: "202"})
+	ti.Cursor.TextStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "15"})
 	
 	m := Model{
 		state:         StateHome,
@@ -170,9 +170,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.state == StateFeedback {
 		// Handle ESC key specially
 		if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "esc" {
-			m.state = StateHome
-			m.feedbackForm.Reset()
-			return m, nil
+			// If on first question, go back to home
+			if m.feedbackForm.currentField == 0 {
+				m.state = StateHome
+				m.feedbackForm.Reset()
+				return m, nil
+			}
+			// Otherwise let the form handle going back
 		}
 		
 		// Update custom feedback form

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -5,20 +5,18 @@ import (
 )
 
 var (
-	// Colors
-	primaryColor   = lipgloss.Color("#FFFFFF")
-	secondaryColor = lipgloss.Color("#888888")
-	accentColor    = lipgloss.Color("#FF6600")
-	bgColor        = lipgloss.Color("#000000")
+	// Colors - using adaptive colors for better terminal compatibility
+	primaryColor   = lipgloss.AdaptiveColor{Light: "0", Dark: "15"}    // Black in light mode, White in dark mode
+	secondaryColor = lipgloss.AdaptiveColor{Light: "8", Dark: "7"}     // Gray
+	accentColor    = lipgloss.AdaptiveColor{Light: "202", Dark: "202"} // Orange (ANSI 256 color)
+	bgColor        = lipgloss.NoColor{}                                // No explicit background
 
 	// Base styles
 	baseStyle = lipgloss.NewStyle().
-			Background(bgColor).
 			Foreground(primaryColor)
 
-	// Full screen style to enforce dark background
+	// Full screen style
 	fullScreenStyle = lipgloss.NewStyle().
-			Background(bgColor).
 			Foreground(primaryColor)
 
 	// Navigation bar styles
@@ -26,7 +24,6 @@ var (
 			BorderStyle(lipgloss.NormalBorder()).
 			BorderBottom(true).
 			BorderForeground(secondaryColor).
-			Background(bgColor).
 			Padding(0, 1)
 
 	navItemStyle = lipgloss.NewStyle().
@@ -39,7 +36,6 @@ var (
 
 	// Content area styles
 	contentStyle = lipgloss.NewStyle().
-			Background(bgColor).
 			Padding(1, 2)
 
 	// Title styles
@@ -82,8 +78,7 @@ var (
 	// Border styles for main container
 	containerStyle = lipgloss.NewStyle().
 			BorderStyle(lipgloss.RoundedBorder()).
-			BorderForeground(secondaryColor).
-			Background(bgColor)
+			BorderForeground(secondaryColor)
 
 	// Help text style
 	helpStyle = lipgloss.NewStyle().
@@ -92,30 +87,26 @@ var (
 
 	// Error style
 	errorStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FF0000"))
+			Foreground(lipgloss.AdaptiveColor{Light: "1", Dark: "9"})
 )
 
 func renderNavBar() string {
 	// Special style for "tmdr" with orange and bold
 	tmdrStyle := lipgloss.NewStyle().
 		Foreground(accentColor).
-		Background(bgColor).
 		Bold(true)
 	
 	// Style for keyboard shortcuts - bold and prominent
 	keyStyle := lipgloss.NewStyle().
 		Foreground(primaryColor).
-		Background(bgColor).
 		Bold(true)
 	
 	// Style for labels - smaller, not bold
 	labelStyle := lipgloss.NewStyle().
-		Foreground(secondaryColor).
-		Background(bgColor)
+		Foreground(secondaryColor)
 	
 	separatorStyle := lipgloss.NewStyle().
-		Foreground(secondaryColor).
-		Background(bgColor)
+		Foreground(secondaryColor)
 	
 	// Build navigation items with bold keys and lighter labels
 	nav := tmdrStyle.Render("tmdr") +

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -17,24 +17,24 @@ func (m Model) View() string {
 	var updateNotification string
 	if m.updateReady {
 		updateNotification = lipgloss.NewStyle().
-			Background(lipgloss.Color("#00AA00")).
-			Foreground(lipgloss.Color("#FFFFFF")).
+			Background(lipgloss.AdaptiveColor{Light: "2", Dark: "10"}).
+			Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "15"}).
 			Padding(0, 1).
 			Width(m.width).
 			Align(lipgloss.Center).
 			Render(fmt.Sprintf("✨ tmdr v%s downloaded! Restart to apply update", m.updateInfo.Version))
 	} else if m.updateDownloading {
 		updateNotification = lipgloss.NewStyle().
-			Background(lipgloss.Color("#FF6600")).
-			Foreground(lipgloss.Color("#FFFFFF")).
+			Background(lipgloss.AdaptiveColor{Light: "202", Dark: "202"}).
+			Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "15"}).
 			Padding(0, 1).
 			Width(m.width).
 			Align(lipgloss.Center).
 			Render(fmt.Sprintf("⬇️ Downloading tmdr v%s...", m.updateInfo.Version))
 	} else if m.updateInfo.Available && m.updateError == nil {
 		updateNotification = lipgloss.NewStyle().
-			Background(lipgloss.Color("#0066CC")).
-			Foreground(lipgloss.Color("#FFFFFF")).
+			Background(lipgloss.AdaptiveColor{Light: "4", Dark: "12"}).
+			Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "15"}).
 			Padding(0, 1).
 			Width(m.width).
 			Align(lipgloss.Center).
@@ -59,10 +59,9 @@ func (m Model) View() string {
 	navContent := renderNavBar()
 	navBar := lipgloss.NewStyle().
 		Width(m.width - 2).
-		Background(bgColor).
 		BorderStyle(lipgloss.NormalBorder()).
 		BorderBottom(true).
-		BorderForeground(lipgloss.Color("#888888")).
+		BorderForeground(lipgloss.AdaptiveColor{Light: "8", Dark: "7"}).
 		Padding(0, 1).
 		Render(navContent)
 
@@ -107,23 +106,14 @@ func (m Model) View() string {
 }
 
 func (m Model) viewHome() string {
-	// Center text manually using string padding
+	// Use PlaceHorizontal for centering without background artifacts
 	width := m.width - 4
-	titleText := "too medical; didn't read"
-	subtitleText := "Your terminal-native tool for instant medical acronym help."
-	
-	// Calculate padding for centering
-	titlePadding := (width - len(titleText)) / 2
-	if titlePadding < 0 {
-		titlePadding = 0
-	}
-	subtitlePadding := (width - len(subtitleText)) / 2
-	if subtitlePadding < 0 {
-		subtitlePadding = 0
+	if width < 1 {
+		width = 1
 	}
 	
-	title := strings.Repeat(" ", titlePadding) + titleStyle.Render(titleText)
-	subtitle := strings.Repeat(" ", subtitlePadding) + subtitleStyle.Render(subtitleText)
+	title := lipgloss.PlaceHorizontal(width, lipgloss.Center, titleStyle.Render("too medical; didn't read"))
+	subtitle := lipgloss.PlaceHorizontal(width, lipgloss.Center, subtitleStyle.Render("Your terminal-native tool for instant medical acronym help."))
 	
 	// Adjust content based on available height
 	var content string
@@ -137,22 +127,14 @@ func (m Model) viewHome() string {
 			"    • Press 'h' or 't' to return home",
 		}
 		
-		// Center instructions
+		// Center each instruction line
 		centeredInstructions := make([]string, len(instructions))
 		for i, line := range instructions {
-			padding := (width - len(line)) / 2
-			if padding < 0 {
-				padding = 0
-			}
-			centeredInstructions[i] = strings.Repeat(" ", padding) + line
+			centeredInstructions[i] = lipgloss.PlaceHorizontal(width, lipgloss.Center, line)
 		}
 		
 		dataInfo := fmt.Sprintf("⚙️  version: v%s", version.Version)
-		dataInfoPadding := (width - len(dataInfo)) / 2
-		if dataInfoPadding < 0 {
-			dataInfoPadding = 0
-		}
-		centeredDataInfo := strings.Repeat(" ", dataInfoPadding) + dataInfo
+		centeredDataInfo := lipgloss.PlaceHorizontal(width, lipgloss.Center, dataInfo)
 		
 		content = lipgloss.JoinVertical(
 			lipgloss.Left,
@@ -167,11 +149,7 @@ func (m Model) viewHome() string {
 	} else {
 		// Compact version for smaller terminals
 		shortcuts := "s: search | b: browse | f: feedback"
-		shortcutsPadding := (width - len(shortcuts)) / 2
-		if shortcutsPadding < 0 {
-			shortcutsPadding = 0
-		}
-		centeredShortcuts := strings.Repeat(" ", shortcutsPadding) + shortcuts
+		centeredShortcuts := lipgloss.PlaceHorizontal(width, lipgloss.Center, shortcuts)
 		
 		content = lipgloss.JoinVertical(
 			lipgloss.Left,
@@ -343,18 +321,16 @@ func (m Model) viewFeedback() string {
 		formView = m.feedbackForm.View()
 	}
 	
-	help := helpStyle.Render("Navigate with ↑↓ • Select with Enter • Press ESC to go back")
+	// Debug: If form is empty, show a message
+	if formView == "" {
+		formView = "Error: Feedback form not initialized"
+	}
 	
-	content := lipgloss.JoinVertical(
-		lipgloss.Left,
-		"",
-		formView,
-		"",
-		help,
-	)
+	content := formView
 
+	// Don't restrict height for feedback form to prevent truncation
 	return contentStyle.
 		Width(m.width - 4).
-		Height(m.height - 6).
+		Padding(1, 2).
 		Render(content)
 }


### PR DESCRIPTION
## Summary
- Fixed white box rendering issues in Terminal.app while maintaining iTerm2 compatibility
- Replaced hardcoded hex colors with adaptive ANSI colors for better terminal support
- Removed explicit background colors that were causing rendering conflicts

## Changes
- Updated `internal/tui/styles.go` to use `lipgloss.AdaptiveColor` instead of hex colors
- Fixed text input cursor styling in `internal/tui/model.go` 
- Removed conflicting background colors from views
- Updated feedback form colors for consistency

## Testing
- ✅ Tested in Terminal.app - no more white boxes
- ✅ Tested in iTerm2 - still works correctly
- ✅ All text is now readable in both terminals

## Before/After
**Before:** White boxes appearing where text should be in Terminal.app
**After:** Proper text rendering with correct colors in both Terminal.app and iTerm2

Fixes display issues reported in Terminal.app where white boxes were shown instead of text content.